### PR TITLE
Fixing ota with insecure api call

### DIFF
--- a/src/ota.cpp
+++ b/src/ota.cpp
@@ -151,7 +151,7 @@ int do_ota_update() {
   WiFiClientSecure client;
 
   client.setTimeout(RESPONSE_TIMEOUT_MS);
-
+  client.setInsecure();
   if (!client.connect(currentHost.c_str(), port)) {
     ESP_LOGI(TAG, "Cannot connect to %s", currentHost.c_str());
     ota_display(3, " E", "connection lost");


### PR DESCRIPTION
As discuessed in https://github.com/espressif/arduino-esp32/issues/4745 the WiFiClientSecure has to be set to insecure by API at a the newer version of the espressif platform.

This MR adds the API call.
Also is rebased to current paxcounter project master.